### PR TITLE
install rstudio v 1.1 [hold]

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -48,3 +48,9 @@ USER root
 RUN echo "\n\n if [ ! -d /home/\$USER/tutorials ]; then\n\t git clone https://github.com/terraref/tutorials.git /home/\$USER/tutorials\nfi\n" >> /etc/cont-init.d/userconf && \
     echo "\nchown -R \$USER /home/\$USER/tutorials" >> /etc/cont-init.d/userconf  && \
     echo "\n if [ ! -d /home\$USER/data ]; then\n\tln -s /data/ /home/\$USER/data\nfi\n" >> /etc/cont-init.d/userconf
+    
+RUN apt-get update && \
+    apt-get install gdebi-core && \\
+    wget https://download2.rstudio.org/rstudio-server-1.1.383-amd64.deb && \\
+    gdebi -n rstudio-server-1.1.383-amd64.deb
+    

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -49,8 +49,8 @@ RUN echo "\n\n if [ ! -d /home/\$USER/tutorials ]; then\n\t git clone https://gi
     echo "\nchown -R \$USER /home/\$USER/tutorials" >> /etc/cont-init.d/userconf  && \
     echo "\n if [ ! -d /home\$USER/data ]; then\n\tln -s /data/ /home/\$USER/data\nfi\n" >> /etc/cont-init.d/userconf
     
-RUN apt-get update && \
-    apt-get install gdebi-core && \\
+RUN apt-get -y update && \
+    apt-get -y install gdebi-core && \\
     wget https://download2.rstudio.org/rstudio-server-1.1.383-amd64.deb && \\
     gdebi -n rstudio-server-1.1.383-amd64.deb
     


### PR DESCRIPTION
This should not need to be installed because the rocker/geospatial source should always provide the most recent version of rstudio (per documentation https://github.com/rocker-org/rocker-versioned#images) 

However, the last few images I've created on the workbench have rstudio 3.0.x instead of 3.1.x

this may not need to be merged, but I wanted to keep the changes while I am at it (and can at least run the last statement if needed when I create a new image).