### PR TITLE
added ncdf4 package

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -40,6 +40,7 @@ RUN install2.r --error \
     convertr \
     ggthemes \
     ncdf.tools \
+    ncdf4 \
     rLiDAR \
     leaflet \
     shinythemes 


### PR DESCRIPTION
appears to have been removed from upstream rocker-org/geospatial image as of 3.3.0, but is required for much of the tutorials / and is one of the more useful libraries for netcdf .