### PR TITLE
update rstudio dockerfile to support terrautils

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update -y &&  \
          sqlite3 \
          libopencv-dev \
          libsqliteodbc \
-         python-matplotlib  && \
+         python-matplotlib  \
+         python-gdal && \
     easy_install pip && \
     pip install \
          numpy \
@@ -26,11 +27,13 @@ RUN apt-get update -y &&  \
          sympy \
          nose \
          scikit-image \
-         opencv-python  && \
+         opencv-python \
+         terrautils && \
     pip3 install \
          numpy \
          scipy \
-         matplotlib  && \
+         matplotlib  \
+         terrautils && \
      apt-get clean && \
      rm -rf /var/lib/apt/lists/*
 

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -y &&  \
          sqlite3 \
          libopencv-dev \
          libsqliteodbc \
+         nco \
          python-matplotlib  \
          python-gdal && \
     easy_install pip && \


### PR DESCRIPTION
this worked on the demo after installing python-gdal as root I could install terrautils. Need to check to make sure that nothing breaks before merging